### PR TITLE
Clamp acos input to [-1, 1] to avoid returning NaN

### DIFF
--- a/dist/es5/index.js
+++ b/dist/es5/index.js
@@ -32,11 +32,12 @@ var scaleVector = function scaleVector(p1, p2, factor) {
 var makeBezierPoints = function makeBezierPoints(p1, p2, p3, radius) {
     // Angle between lines
     var PI = Math.PI,
-        abs = Math.abs,
         sqrt = Math.sqrt,
         pow = Math.pow,
         acos = Math.acos,
-        tan = Math.tan;
+        tan = Math.tan,
+        min = Math.min,
+        max = Math.max;
     var x1 = p1.x,
         y1 = p1.y;
     var x2 = p2.x,
@@ -44,10 +45,11 @@ var makeBezierPoints = function makeBezierPoints(p1, p2, p3, radius) {
     var x3 = p3.x,
         y3 = p3.y;
 
-    var a = sqrt(pow(abs(x2 - x1), 2) + pow(abs(y2 - y1), 2));
-    var b = sqrt(pow(abs(x3 - x2), 2) + pow(abs(y3 - y2), 2));
-    var c = sqrt(pow(abs(x3 - x1), 2) + pow(abs(y3 - y1), 2));
-    var angle = acos((pow(a, 2) + (pow(b, 2) - pow(c, 2))) / (2 * a * b)); // cos theoreme
+    var a = sqrt(pow(x2 - x1, 2) + pow(y2 - y1, 2));
+    var b = sqrt(pow(x3 - x2, 2) + pow(y3 - y2, 2));
+    var c = sqrt(pow(x3 - x1, 2) + pow(y3 - y1, 2));
+    var cosC = (pow(a, 2) + pow(b, 2) - pow(c, 2)) / (2 * a * b); // cos theorem's
+    var angle = acos(min(max(-1, cosC), 1)); // clamp acos parameter to [-1, 1]
 
     // Angle between any side and line from circle center to angle vertex
     var angle2 = PI / 2 - angle / 2;

--- a/dist/es6/index.js
+++ b/dist/es6/index.js
@@ -20,14 +20,15 @@ const scaleVector = (p1, p2, factor) => {
 
 const makeBezierPoints = (p1, p2, p3, radius) => {
     // Angle between lines
-    const { PI, abs, sqrt, pow, acos, tan } = Math;
+    const { PI, sqrt, pow, acos, tan, min, max } = Math;
     const { x: x1, y: y1 } = p1;
     const { x: x2, y: y2 } = p2;
     const { x: x3, y: y3 } = p3;
-    const a = sqrt(pow(abs(x2 - x1), 2) + pow(abs(y2 - y1), 2));
-    const b = sqrt(pow(abs(x3 - x2), 2) + pow(abs(y3 - y2), 2));
-    const c = sqrt(pow(abs(x3 - x1), 2) + pow(abs(y3 - y1), 2));
-    const angle = acos((pow(a, 2) + (pow(b, 2) - pow(c, 2))) / (2 * a * b)); // cos theoreme
+    const a = sqrt(pow(x2 - x1, 2) + pow(y2 - y1, 2));
+    const b = sqrt(pow(x3 - x2, 2) + pow(y3 - y2, 2));
+    const c = sqrt(pow(x3 - x1, 2) + pow(y3 - y1, 2));
+    const cosC = (pow(a, 2) + pow(b, 2) - pow(c, 2)) / (2 * a * b); // cos theorem's
+    const angle = acos(min(max(-1, cosC), 1)); // clamp acos parameter to [-1, 1]
 
     // Angle between any side and line from circle center to angle vertex
     const angle2 = PI / 2 - angle / 2;

--- a/src/index.js
+++ b/src/index.js
@@ -20,14 +20,15 @@ const scaleVector = (p1: TPoint, p2: TPoint, factor: number): TPoint => {
 
 const makeBezierPoints = (p1: TPoint, p2: TPoint, p3: TPoint, radius: number) => {
     // Angle between lines
-    const {PI, abs, sqrt, pow, acos, tan} = Math
+    const {PI, sqrt, pow, acos, tan, min, max} = Math
     const {x: x1, y: y1} = p1
     const {x: x2, y: y2} = p2
     const {x: x3, y: y3} = p3
-    const a = sqrt(pow(abs(x2 - x1), 2) + pow(abs(y2 - y1), 2))
-    const b = sqrt(pow(abs(x3 - x2), 2) + pow(abs(y3 - y2), 2))
-    const c = sqrt(pow(abs(x3 - x1), 2) + pow(abs(y3 - y1), 2))
-    const angle = acos((pow(a, 2) + (pow(b, 2) - pow(c, 2))) / (2 * a * b)) // cos theoreme
+    const a = sqrt(pow(x2 - x1, 2) + pow(y2 - y1, 2))
+    const b = sqrt(pow(x3 - x2, 2) + pow(y3 - y2, 2))
+    const c = sqrt(pow(x3 - x1, 2) + pow(y3 - y1, 2))
+    const cosC = (pow(a, 2) + pow(b, 2) - pow(c, 2)) / (2 * a * b) // cos theorem's
+    const angle = acos(min(max(-1, cosC), 1)) // clamp acos parameter to [-1, 1]
 
     // Angle between any side and line from circle center to angle vertex
     const angle2 = (PI / 2) - (angle / 2)


### PR DESCRIPTION
- because of imprecise float representation in memory the calculation of
cosinus (sometimes?) yielded something like 1.0000000002 when the input
points were collinear; this number was then passed to Math.acos which
returns NaN when the input is not between -1 and 1, thus messing the
entire calculated path coordinates
- also remove abs calls when computing the length of the triangle sides,
because squaring a number guarantees positive output (required for sqrt)
- fix bad spelling of 'theorem'